### PR TITLE
Add Puppeteer plugins to speed up Spigot requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# Folders
 node_modules
-logs
-data/servers.json
-data/plugins.json
+logs/
 data/temp
 data/plugins
 data/servers
+.vscode/
+
+# Files
+data/servers.json
+data/plugins.json
 .env
 /*.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,45 @@
 				}
 			}
 		},
+		"@cliqz/adblocker": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.19.0.tgz",
+			"integrity": "sha512-sy/aBjPoQsqLI5XYHAaZfgi+7HpddJmoHn/UMyX0dx0/jnnaM2/Z2LGylOsGwjW97GsNvvqSwXgxsEH2R0K9SQ==",
+			"requires": {
+				"@remusao/guess-url-type": "^1.1.2",
+				"@remusao/small": "^1.1.2",
+				"@remusao/smaz": "^1.7.1",
+				"@types/chrome": "^0.0.127",
+				"@types/firefox-webext-browser": "^82.0.0",
+				"tldts-experimental": "^5.6.21"
+			},
+			"dependencies": {
+				"@types/chrome": {
+					"version": "0.0.127",
+					"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.127.tgz",
+					"integrity": "sha512-hBB9EApLYKKn2GvklVkTxVP6vZvxsH9okyIRUinNtMzZHIgIKWQk/ESbX+O5g4Bihfy38+aFGn7Kl7Cxou5JUg==",
+					"requires": {
+						"@types/filesystem": "*",
+						"@types/har-format": "*"
+					}
+				}
+			}
+		},
+		"@cliqz/adblocker-content": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.19.0.tgz",
+			"integrity": "sha512-sciMicb+zmN5+iKCiDnWPegepgI32XzX4Snf1VxR+HAFwYGJmfk25vpL6ONd6hOlpmumxHkE/y5l7suH0ziP5g=="
+		},
+		"@cliqz/adblocker-puppeteer": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.19.0.tgz",
+			"integrity": "sha512-mjs2iYFdoFpudq0E6y6DbcM98Ylc5dyBQLMc/Zj5CkDE2YIGL7XonB16Jw6AUOo5b7l8MoyEYNXpO7TWGAk0JQ==",
+			"requires": {
+				"@cliqz/adblocker": "^1.19.0",
+				"@cliqz/adblocker-content": "^1.19.0",
+				"tldts-experimental": "^5.6.21"
+			}
+		},
 		"@discordjs/collection": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.1.6.tgz",
@@ -128,6 +167,43 @@
 				}
 			}
 		},
+		"@remusao/guess-url-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@remusao/guess-url-type/-/guess-url-type-1.2.1.tgz",
+			"integrity": "sha512-rbOqre2jW8STjheOsOaQHLgYBaBZ9Owbdt8NO7WvNZftJlaG3y/K9oOkl8ZUpuFBisIhmBuMEW6c+YrQl5inRA=="
+		},
+		"@remusao/small": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@remusao/small/-/small-1.2.1.tgz",
+			"integrity": "sha512-7MjoGt0TJMVw1GPKgWq6SJPws1SLsUXQRa43Umht+nkyw2jnpy3WpiLNqGdwo5rHr5Wp9B2W/Pm5RQp656UJdw=="
+		},
+		"@remusao/smaz": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@remusao/smaz/-/smaz-1.9.1.tgz",
+			"integrity": "sha512-e6BLuP8oaXCZ9+v46Is4ilAZ/Vq6YLgmBP204Ixgk1qTjXmqvFYG7+AS7v9nsZdGOy96r9DWGFbbDVgMxwu1rA==",
+			"requires": {
+				"@remusao/smaz-compress": "^1.9.1",
+				"@remusao/smaz-decompress": "^1.9.1"
+			}
+		},
+		"@remusao/smaz-compress": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@remusao/smaz-compress/-/smaz-compress-1.9.1.tgz",
+			"integrity": "sha512-E2f48TwloQu3r6BdLOGF2aczeH7bJ/32oJGqvzT9SKur0cuUnLcZ7ZXP874E2fwmdE+cXzfC7bKzp79cDnmeyw==",
+			"requires": {
+				"@remusao/trie": "^1.4.1"
+			}
+		},
+		"@remusao/smaz-decompress": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@remusao/smaz-decompress/-/smaz-decompress-1.9.1.tgz",
+			"integrity": "sha512-TfjKKprYe3n47od8auhvJ/Ikj9kQTbDTe71ynKlxslrvvUhlIV3VQSuwYuMWMbdz1fIs0H/fxCN1Z8/H3km6/A=="
+		},
+		"@remusao/trie": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@remusao/trie/-/trie-1.4.1.tgz",
+			"integrity": "sha512-yvwa+aCyYI/UjeD39BnpMypG8N06l86wIDW1/PAc6ihBRnodIfZDwccxQN3n1t74wduzaz74m4ZMHZnB06567Q=="
+		},
 		"@sindresorhus/is": {
 			"version": "0.14.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -143,10 +219,41 @@
 				"defer-to-connect": "^1.0.1"
 			}
 		},
+		"@types/chrome": {
+			"version": "0.0.91",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.91.tgz",
+			"integrity": "sha512-vNvo9lJkp1AvViWrUwe1bxhoMwr5dRZWlgr1DTuaNkz97LsG56lDX1sceWeZir2gRACJ5vdHtoRdVAvm8C75Ug==",
+			"requires": {
+				"@types/filesystem": "*"
+			}
+		},
 		"@types/debug": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
 			"integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
+		},
+		"@types/filesystem": {
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.29.tgz",
+			"integrity": "sha512-85/1KfRedmfPGsbK8YzeaQUyV1FQAvMPMTuWFQ5EkLd2w7szhNO96bk3Rh/SKmOfd9co2rCLf0Voy4o7ECBOvw==",
+			"requires": {
+				"@types/filewriter": "*"
+			}
+		},
+		"@types/filewriter": {
+			"version": "0.0.28",
+			"resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
+			"integrity": "sha1-wFTor02d11205jq8dviFFocU1LM="
+		},
+		"@types/firefox-webext-browser": {
+			"version": "82.0.0",
+			"resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.0.tgz",
+			"integrity": "sha512-zKHePkjMx42KIUUZCPcUiyu1tpfQXH9VR4iDYfns3HvmKVJzt/TAFT+DFVroos8BI9RH78YgF3Hi/wlC6R6cKA=="
+		},
+		"@types/har-format": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.5.tgz",
+			"integrity": "sha512-IG8AE1m2pWtPqQ7wXhFhy6Q59bwwnLwO36v5Rit2FrbXCIp8Sk8E2PfUCreyrdo17STwFSKDAkitVuVYbpEHvQ=="
 		},
 		"@types/node": {
 			"version": "14.14.14",
@@ -2565,6 +2672,57 @@
 				}
 			}
 		},
+		"puppeteer-extra-plugin-adblocker": {
+			"version": "2.11.9",
+			"resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-adblocker/-/puppeteer-extra-plugin-adblocker-2.11.9.tgz",
+			"integrity": "sha512-Sn6Sn8NtqrVllITN7rvONkoXQnfQXQ9EH/iyDpQPJ9QaXv8Y9nm8YFhF9MzKNs4Z5NqPSLc6dnOThwfjmKTXFw==",
+			"requires": {
+				"@cliqz/adblocker-puppeteer": "^1.18.6",
+				"@types/chrome": "0.0.91",
+				"debug": "^4.1.1",
+				"node-fetch": "^2.6.0",
+				"puppeteer-extra-plugin": "^3.1.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
+		"puppeteer-extra-plugin-block-resources": {
+			"version": "2.2.7",
+			"resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-block-resources/-/puppeteer-extra-plugin-block-resources-2.2.7.tgz",
+			"integrity": "sha512-u2vcynnB9pINEVs7ZQs7DS8cJ2eedD0paL1M8ZdpNOQMCZ4zAVRwUpXF6T5v865nMu5srDnA3fTfdv6Ak0DG0g==",
+			"requires": {
+				"debug": "^4.1.1",
+				"puppeteer-extra-plugin": "^3.1.7"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
 		"puppeteer-extra-plugin-stealth": {
 			"version": "2.6.5",
 			"resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.6.5.tgz",
@@ -3040,6 +3198,19 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
 			"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+		},
+		"tldts-core": {
+			"version": "5.6.80",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.6.80.tgz",
+			"integrity": "sha512-yTsYxJg4UeXbsex/eWM7fSW9UeusaTsXUcovVf9E8h0mh5OD+P1nS9xiHekBcuKltSl8kYkQSDqbYpq9r+G+kw=="
+		},
+		"tldts-experimental": {
+			"version": "5.6.80",
+			"resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-5.6.80.tgz",
+			"integrity": "sha512-Rzq3HZKUWxMAfO6IEXF/eVxfcgHybxItQPtcDgQasazXGXmmID6rEwHPiNtGXjsMpeSpw9g+5oZxf6cE18IVVA==",
+			"requires": {
+				"tldts-core": "^5.6.80"
+			}
 		},
 		"to-buffer": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
 		"node-fetch": "^2.6.1",
 		"puppeteer": "^5.5.0",
 		"puppeteer-extra": "^3.1.15",
+		"puppeteer-extra-plugin-adblocker": "^2.11.9",
+		"puppeteer-extra-plugin-block-resources": "^2.2.7",
 		"puppeteer-extra-plugin-stealth": "^2.6.5",
 		"sequelize": "^6.3.5",
 		"unzipper": "^0.10.11"

--- a/src/spigot/check.js
+++ b/src/spigot/check.js
@@ -1,13 +1,9 @@
 const puppeteer = require('puppeteer-extra');
 const StealthPlugin = require('puppeteer-extra-plugin-stealth');
 const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker');
-const BlockResourcesPlugin = require('puppeteer-extra-plugin-block-resources');
 
 puppeteer.use(StealthPlugin());
 puppeteer.use(AdblockerPlugin());
-puppeteer.use(BlockResourcesPlugin({
-	blockedTypes: new Set(['image', 'stylesheet'])
-}));
 
 module.exports = async bot => {
 

--- a/src/spigot/check.js
+++ b/src/spigot/check.js
@@ -1,7 +1,13 @@
 const puppeteer = require('puppeteer-extra');
 const StealthPlugin = require('puppeteer-extra-plugin-stealth');
+const AdblockerPlugin = require('puppeteer-extra-plugin-adblocker');
+const BlockResourcesPlugin = require('puppeteer-extra-plugin-block-resources');
 
 puppeteer.use(StealthPlugin());
+puppeteer.use(AdblockerPlugin());
+puppeteer.use(BlockResourcesPlugin({
+	blockedTypes: new Set(['image', 'stylesheet'])
+}));
 
 module.exports = async bot => {
 


### PR DESCRIPTION
These don't add *that* much weight to installing and should hopefully improve the speed of Spigot requests a fair bit.

Here's a test I locally ran with and without the Edge tracking prevention on Spigot homepage to give you an idea of how much faster it might be using the adblocker:

![ZTKEKMF1DH](https://user-images.githubusercontent.com/14052956/103890358-d7992880-50df-11eb-8903-8acd03516cb9.png)
![wDSByRrZGi](https://user-images.githubusercontent.com/14052956/103890349-d405a180-50df-11eb-9dea-6cae3bfae697.png)

Of course, with the block resources plugin it should reduce the data usage even further.

Untested as usual but I see no reason why it wouldn't work.
